### PR TITLE
Python-based model execution and convergence

### DIFF
--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -21,9 +21,12 @@ class Compiler(object):
         self._cppargs = cppargs
         self._ldargs = ldargs
 
-    def compile(self, src, out=None):
+    def compile(self, src, out=None, shared=True):
         basename = src.split('.')[0]
-        outname = out or "%s" % basename
+        outname = out or "%s.so"%basename if shared else basename
+        if shared:
+            self._cppargs += ['-fPIC']
+            self._ldargs += ['-shared']
         cc = [self._cc] + self._cppargs + ['-o', outname, src] + self._ldargs
         with file('%s.log' % basename, 'w') as logfile:
             logfile.write("Compiling: %s\n" % " ".join(cc))
@@ -33,7 +36,8 @@ class Compiler(object):
                 print "Compilation error with:", " ".join(cc)
                 print "Log file:", logfile.name
                 raise RuntimeError("Error during compilation")
-            print "Compiled:", outname
+        print "Compiled:", outname
+        return outname
 
 
 class GNUCompiler(Compiler):

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -1,0 +1,46 @@
+from compilation import GNUCompiler
+
+from StringIO import StringIO
+from mako.runtime import Context
+
+class Grid:
+    """Base class for grid objects that provides the code generation,
+    compilation and execution infrastructure"""
+
+    # mako.lookup.TemplateLookup object
+    lookup = None
+
+    # Name of the base template
+    template_base = None
+
+    # List of keys used the template that corresponds to an equivalent
+    # property field in the derived grid class
+    template_keys = []
+
+    def generate(self, filename):
+        # Generate a dictionary that maps template keys to code fragments
+        template = self.lookup.get_template(self.template_base)
+        template_keys = dict([(k, getattr(self, k)) for k in self.template_keys])
+
+        # Render code from provided template
+        buf = StringIO()
+        ctx = Context(buf, **template_keys)
+        template.render_context(ctx)
+        self.src_code = buf.getvalue()
+
+        # Generate compilable source code
+        self.src_file = filename
+        with file(self.src_file, 'w') as f:
+            f.write(self.src_code)
+
+        print "Generated:", self.src_file
+
+    def compile(self, filename, compiler='g++'):
+        # Generate code if this hasn't been done yet
+        if self.src_file is None:
+            self.generate(filename)
+
+        # Compile cource file with appropriate compiler
+        if compiler in ['g++', 'gnu']:
+            self._compiler = GNUCompiler()
+            self._compiler.compile(self.src_file)

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -17,6 +17,11 @@ class Grid:
     # property field in the derived grid class
     template_keys = []
 
+    # Placeholders for generated code and associated files
+    src_code = None
+    src_file = None
+    src_lib = None
+
     def generate(self, filename):
         # Generate a dictionary that maps template keys to code fragments
         template = self.lookup.get_template(self.template_base)
@@ -35,12 +40,14 @@ class Grid:
 
         print "Generated:", self.src_file
 
-    def compile(self, filename, compiler='g++'):
+    def compile(self, filename, compiler='g++', shared=True):
         # Generate code if this hasn't been done yet
         if self.src_file is None:
             self.generate(filename)
 
-        # Compile cource file with appropriate compiler
+        # Compile source file with appropriate compiler
         if compiler in ['g++', 'gnu']:
             self._compiler = GNUCompiler()
-            self._compiler.compile(self.src_file)
+            out = self._compiler.compile(self.src_file, shared=shared)
+        if shared:
+            self.src_lib = out

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -24,6 +24,25 @@ class Grid:
     src_file = None
     src_lib = None
 
+    # Dynamic execution objects
+    _library = None
+    _arg_grid = None
+    _arg_conv = None
+
+    def __del__(self):
+        # Correctly close compiled kernel library
+        if self._library is not None:
+            cdll.LoadLibrary('libdl.so').dlclose(self._library._handle)
+
+    def _load_library(self, src_lib):
+        """Load a compiled dynamic binary using ctypes.cdll"""
+        libname = src_lib or self.src_lib
+        try:
+            self._library = cdll.LoadLibrary(libname)
+        except OSError as e:
+            print "Library load error: ", e
+            raise Exception("Failed to load %s" % libname)
+
     def generate(self, filename):
         # Generate a dictionary that maps template keys to code fragments
         template = self.lookup.get_template(self.template_base)
@@ -60,31 +79,44 @@ class Grid:
             self.compile(filename, compiler=compiler, shared=True)
 
         # Load compiled binary
-        try:
-            library = cdll.LoadLibrary(self.src_lib)
-        except OSError as e:
-            print "Library load error: ", e
-            raise Exception("Failed to load %s" % self.src_lib)
+        self._load_library(src_lib=self.src_lib)
 
-        # Define our custom OpesciGrid struct
+        # Define OpesciGrid struct
         class OpesciGrid(Structure):
             _fields_ = [(ccode(f.label), POINTER(c_float)) for f in self.fields]
 
-        # Execute opesci_run function with grid struct
-        grid_arg = OpesciGrid()
-        grid_arg.values = [POINTER(c_float)() for f in self.fields]
+        # Generate the grid argument
+        self._arg_grid = OpesciGrid()
+        self._arg_grid.values = [POINTER(c_float)() for f in self.fields]
 
         # Load opesci_run, define it's arguments and run
         print "Executing core computation..."
-        opesci_execute = library.opesci_execute
+        opesci_execute = self._library.opesci_execute
         opesci_execute.argtypes = [POINTER(OpesciGrid)]
-        opesci_execute(pointer(grid_arg))
+        opesci_execute(pointer(self._arg_grid))
+
+    def convergence(self):
+        """Compute L2 norms for convergence testing"""
+        if self._library is None:
+            self._load_library()
+        if self._arg_grid is None:
+            raise RuntimeError("""Convergence could not find grid argument!
+You need to you run grid.execute() first!""")
+
+        # Define OpesciConvergence struct
+        class OpesciConvergence(Structure):
+            _fields_ = [('%s_l2' % ccode(f.label), c_float)
+                        for f in self.fields]
+
+        # Generate the convergence argument
+        arg_conv = OpesciConvergence()
+        arg_conv.values = [c_float(0.) for f in self.fields]
 
         # Load opesci_convergence, define it's arguments and run
-        print "Computing convergence:"
-        opesci_convergence = library.opesci_convergence
-        opesci_convergence.argtypes = [POINTER(OpesciGrid)]
-        opesci_convergence(pointer(grid_arg))
-
-        # Close compiled kernel library
-        cdll.LoadLibrary('libdl.so').dlclose(library._handle)
+        print "Convergence:"
+        opesci_convergence = self._library.opesci_convergence
+        opesci_convergence.argtypes = [POINTER(self._arg_grid.__class__),
+                                       POINTER(OpesciConvergence)]
+        opesci_convergence(pointer(self._arg_grid), pointer(arg_conv))
+        for field, _ in arg_conv._fields_:
+            print "%s: %.10f" % (field, getattr(arg_conv, field))

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -66,7 +66,6 @@ class StaggeredGrid(Grid):
         template_dir = path.join(get_package_dir(), "templates")
         staggered_dir = path.join(get_package_dir(), "templates/staggered")
         self.lookup = TemplateLookup(directories=[template_dir, staggered_dir])
-        self.src_file = None
 
         # List of associated fields
         self.sfields = []

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -10,7 +10,11 @@
 #include <cstdio>
 #include <string>
 
-int main(){
+struct OpesciGrid {
+${define_fields}
+};
+
+int opesci_execute(OpesciGrid *grid) {
 
 ${define_constants}
 ${declare_fields}
@@ -34,7 +38,23 @@ ${output_step}
 } // end of time loop
 } // end of parallel section
 
-${converge_test}
+${store_fields}
 
 return 0;
+}
+
+int opesci_convergence(OpesciGrid *grid) {
+${define_constants}
+${load_fields}
+
+${converge_test}
+}
+
+int main(){
+  OpesciGrid grid;
+
+  opesci_execute(&grid);
+  opesci_convergence(&grid);
+
+  return 0;
 }

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -34,7 +34,7 @@ ${output_step}
 } // end of time loop
 } // end of parallel section
 
-${output_final}
+${converge_test}
 
 return 0;
 }

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -14,6 +14,10 @@ extern "C" struct OpesciGrid {
 ${define_fields}
 };
 
+extern "C" struct OpesciConvergence {
+${define_convergence}
+};
+
 extern "C" int opesci_execute(OpesciGrid *grid) {
 
 ${define_constants}
@@ -43,7 +47,7 @@ ${store_fields}
 return 0;
 }
 
-extern "C" int opesci_convergence(OpesciGrid *grid) {
+extern "C" int opesci_convergence(OpesciGrid *grid, OpesciConvergence *conv) {
 ${define_constants}
 ${load_fields}
 
@@ -51,10 +55,12 @@ ${converge_test}
 }
 
 int main(){
-  OpesciGrid grid;
+OpesciGrid grid;
+OpesciConvergence conv;
 
-  opesci_execute(&grid);
-  opesci_convergence(&grid);
+opesci_execute(&grid);
+opesci_convergence(&grid, &conv);
+${print_convergence}
 
-  return 0;
+return 0;
 }

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -10,11 +10,11 @@
 #include <cstdio>
 #include <string>
 
-struct OpesciGrid {
+extern "C" struct OpesciGrid {
 ${define_fields}
 };
 
-int opesci_execute(OpesciGrid *grid) {
+extern "C" int opesci_execute(OpesciGrid *grid) {
 
 ${define_constants}
 ${declare_fields}
@@ -43,7 +43,7 @@ ${store_fields}
 return 0;
 }
 
-int opesci_convergence(OpesciGrid *grid) {
+extern "C" int opesci_convergence(OpesciGrid *grid) {
 ${define_constants}
 ${load_fields}
 

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -63,8 +63,8 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
     grid.set_time_step(dt, tmax)
 
     grid.set_switches(omp=omp, simd=simd, ivdep=ivdep, io=io,
-                      double=double, expand=expand,
-                      eval_const=eval_const)
+                      double=double, expand=expand, eval_const=eval_const,
+                      output_vts=o_step, converge=o_converge)
 
     # define parameters
     rho, beta, lam, mu = symbols('rho beta lambda mu')
@@ -139,7 +139,7 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
     grid.set_free_surface_boundary(dimension=3, side=1)
 
     # Generate code and write to output file
-    grid.generate(filename, o_step, o_converge)
+    grid.generate(filename)
 
     # Compile the auto-generated code
     grid.compile(filename, compiler='g++')

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -138,11 +138,7 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
     grid.set_free_surface_boundary(dimension=3, side=0)
     grid.set_free_surface_boundary(dimension=3, side=1)
 
-    # Generate code and write to output file
-    grid.generate(filename)
-
-    # Compile the auto-generated code
-    grid.compile(filename, compiler='g++')
+    return grid
 
 
 def default():
@@ -155,9 +151,15 @@ def default():
     grid_size = (100, 100, 100)
     dt = 0.002
     tmax = 1.0
-    eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
-              omp=True, simd=False, ivdep=True, io=False,
-              filename=path.join(_test_dir, 'eigenwave3d.cpp'))
+    filename = path.join(_test_dir, 'eigenwave3d.cpp')
+    grid = eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False,
+                       o_converge=True, omp=True, simd=False,
+                       ivdep=True, io=False, filename=filename)
+    grid.compile(filename, compiler='g++', shared=False)
+
+    # Test Python-based execution for the base test
+    grid.execute(filename, compiler='g++')
+    grid.convergence()
 
 
 def default_vtk():
@@ -170,9 +172,11 @@ def default_vtk():
     grid_size = (100, 100, 100)
     dt = 0.002
     tmax = 1.0
-    eigenwave3d(domain_size, grid_size, dt, tmax, o_step=True, o_converge=True,
-              omp=True, simd=False, ivdep=True, io=True,
-              filename=path.join(_test_dir, 'eigenwave3d_vtk.cpp'))
+    filename = path.join(_test_dir, 'eigenwave3d_vtk.cpp')
+    grid = eigenwave3d(domain_size, grid_size, dt, tmax, o_step=True,
+                       o_converge=True, omp=True, simd=False,
+                       ivdep=True, io=True, filename=filename)
+    grid.compile(filename, compiler='g++', shared=False)
 
 
 def read_data():
@@ -184,12 +188,12 @@ def read_data():
     grid_size = (195, 195, 195)
     dt = 0.002
     tmax = 1.0
-    eigenwave3d(domain_size, grid_size, dt, tmax, o_step=True, o_converge=False,
-              omp=True, simd=False, ivdep=True, io=True, read=True,
-              filename=path.join(_test_dir, 'eigenwave3d_read.cpp'),
-              rho_file='RHOhomogx200',
-              vp_file='VPhomogx200',
-              vs_file='VShomogx200')
+    filename=path.join(_test_dir, 'eigenwave3d_read.cpp')
+    grid = eigenwave3d(domain_size, grid_size, dt, tmax, o_step=True, o_converge=False,
+                       omp=True, simd=False, ivdep=True, io=True, read=True,
+                       filename=filename, rho_file='RHOhomogx200',
+                       vp_file='VPhomogx200', vs_file='VShomogx200')
+    grid.compile(filename, compiler='g++', shared=False)
 
 
 def cx1():


### PR DESCRIPTION
This merge allows us to execute the generated model and the convergence computation via the Python API (`grid.execute()` and `grid.convergence()`). This will enable more rigorous testing and make automated benchmarking much easier.

Key features in detail:
* Compiler now also compiles dynamic libraries (`mymodel.so`), as well as static self-contained executables (default is dynamic).
* Generated code now has two functions: `opesci_execute()` and `opesci_convergence()`. These are both invoked from `main()`, which passes pointers to field data around in a custom struct `OpesciGrid`. 
* `Grid` class provide ctypes voodoo to create the `OpesciGrid` struct and allows invoking the two functions independently.
* A second struct `OpesciConvergence` is populated with the computed L2 norms in `opesci_convergence()`, which makes them accessible to Python via ctypes wrappers.