### PR TITLE
Intel compiler settings

### DIFF
--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -53,3 +53,7 @@ class GNUCompiler(Compiler):
         ldargs = ['-lopesci', '-Wl,-rpath,%s/lib' % get_package_dir(),
                   '-L%s/lib' % get_package_dir()] + ldargs
         super(GNUCompiler, self).__init__("g++", cppargs=cppargs, ldargs=ldargs)
+
+    @property
+    def _ivdep(self):
+        return '#pragma GCC ivdep'

--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -57,3 +57,21 @@ class GNUCompiler(Compiler):
     @property
     def _ivdep(self):
         return '#pragma GCC ivdep'
+
+
+class IntelCompiler(Compiler):
+    """A compiler object for the Intel compiler toolchain.
+
+    :arg cppargs: A list of arguments to pass to the C compiler
+         (optional).
+    :arg ldargs: A list of arguments to pass to the linker (optional)."""
+    def __init__(self, cppargs=[], ldargs=[]):
+        opt_flags = ['-g', '-O3', '-xHost', '-openmp']
+        cppargs = ['-Wall', '-std=c++11', '-I%s/include' % get_package_dir()] + opt_flags + cppargs
+        ldargs = ['-lopesci', '-Wl,-rpath,%s/lib' % get_package_dir(),
+                  '-L%s/lib' % get_package_dir()] + ldargs
+        super(IntelCompiler, self).__init__("icpc", cppargs=cppargs, ldargs=ldargs)
+
+    @property
+    def _ivdep(self):
+        return '#pragma ivdep'

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -1,4 +1,4 @@
-from compilation import GNUCompiler
+from compilation import GNUCompiler, IntelCompiler
 from codeprinter import ccode
 
 from StringIO import StringIO
@@ -69,6 +69,8 @@ class Grid:
         # First set appropriate compiler
         if compiler in ['g++', 'gnu']:
             self.compiler = GNUCompiler()
+        elif compiler in ['icpc', 'intel']:
+            self.compiler = IntelCompiler()
 
         # Generate code if this hasn't been done yet
         if self.src_file is None:

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -6,7 +6,7 @@ from mako.runtime import Context
 from ctypes import cdll, Structure, POINTER, c_float, pointer
 
 
-class Grid:
+class Grid(object):
     """Base class for grid objects that provides the code generation,
     compilation and execution infrastructure"""
 
@@ -21,7 +21,7 @@ class Grid:
     template_keys = []
 
     # Default compiler is GNU
-    compiler = GNUCompiler()
+    _compiler = GNUCompiler()
 
     # Placeholders for generated code and associated files
     src_code = None
@@ -47,7 +47,23 @@ class Grid:
             print "Library load error: ", e
             raise Exception("Failed to load %s" % libname)
 
-    def generate(self, filename):
+    @property
+    def compiler(self):
+        return self._compiler
+
+    @compiler.setter
+    def compiler(self, compiler):
+        if compiler in ['g++', 'gnu']:
+            self.compiler = GNUCompiler()
+        elif compiler in ['icpc', 'intel']:
+            self.compiler = IntelCompiler()
+        else:
+            raise ValueError("Unknown compiler.")
+
+    def generate(self, filename, compiler=None):
+        if compiler:
+            compiler = compiler
+
         # Generate a dictionary that maps template keys to code fragments
         template = self.lookup.get_template(self.template_base)
         template_keys = dict([(k, getattr(self, k)) for k in self.template_keys])
@@ -65,14 +81,9 @@ class Grid:
 
         print "Generated:", self.src_file
 
-    def compile(self, filename, compiler='g++', shared=True):
-        # First set appropriate compiler
-        if compiler in ['g++', 'gnu']:
-            self.compiler = GNUCompiler()
-        elif compiler in ['icpc', 'intel']:
-            self.compiler = IntelCompiler()
-        else:
-            raise ValueError("Unknown compiler.")
+    def compile(self, filename, compiler=None, shared=True):
+        if compiler:
+            compiler = compiler
 
         # Generate code if this hasn't been done yet
         if self.src_file is None:

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -71,6 +71,8 @@ class Grid:
             self.compiler = GNUCompiler()
         elif compiler in ['icpc', 'intel']:
             self.compiler = IntelCompiler()
+        else:
+            raise ValueError("Unknown compiler.")
 
         # Generate code if this hasn't been done yet
         if self.src_file is None:

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -20,6 +20,9 @@ class Grid:
     # property field in the derived grid class
     template_keys = []
 
+    # Default compiler is GNU
+    compiler = GNUCompiler()
+
     # Placeholders for generated code and associated files
     src_code = None
     src_file = None
@@ -63,14 +66,16 @@ class Grid:
         print "Generated:", self.src_file
 
     def compile(self, filename, compiler='g++', shared=True):
+        # First set appropriate compiler
+        if compiler in ['g++', 'gnu']:
+            self.compiler = GNUCompiler()
+
         # Generate code if this hasn't been done yet
         if self.src_file is None:
             self.generate(filename)
 
-        # Compile source file with appropriate compiler
-        if compiler in ['g++', 'gnu']:
-            self._compiler = GNUCompiler()
-            out = self._compiler.compile(self.src_file, shared=shared)
+        # Compile source file
+        out = self.compiler.compile(self.src_file, shared=shared)
         if shared:
             self.src_lib = out
 

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -828,7 +828,7 @@ class StaggeredGrid(Grid):
             dict1 = {'i': i, 'i0': i0, 'i1': i1, 'body': body}
             body = render(tmpl, dict1)
             if self.ivdep and d == self.dimension-1:
-                    body = '#pragma ivdep\n' + body
+                    body = '%s\n' % self.compiler._ivdep + body
             if self.simd and d == self.dimension-1:
                     body = '#pragma simd\n' + body
 
@@ -866,7 +866,7 @@ class StaggeredGrid(Grid):
             dict1 = {'i': i, 'i0': i0, 'i1': i1, 'body': body}
             body = render(tmpl, dict1)
             if self.ivdep and d == self.dimension-1:
-                    body = '#pragma ivdep\n' + body
+                    body = '%s\n' % self.compiler._ivdep + body
             if self.simd and d == self.dimension-1:
                     body = '#pragma simd\n' + body
 
@@ -909,7 +909,7 @@ class StaggeredGrid(Grid):
                                 body = render(tmpl, dict1).replace('[t]',
                                                                    '[t1]')
                                 if self.ivdep:
-                                    body = '#pragma ivdep\n' + body
+                                    body = '%s\n' % self.compiler._ivdep + body
                                 if self.simd:
                                     body = '#pragma simd\n' + body
                             else:
@@ -960,7 +960,7 @@ class StaggeredGrid(Grid):
                                 body = render(tmpl, dict1).replace('[t]',
                                                                    '[t1]')
                                 if self.ivdep:
-                                    body = '#pragma ivdep\n' + body
+                                    body = '%s\n' % self.compiler._ivdep + body
                                 if self.simd:
                                     body = '#pragma simd\n' + body
                             else:


### PR DESCRIPTION
Adds default settings for the Intel compiler tool chain when used from the Python wappers. Please note that the `ivdep` pragma used for code-gen is compiler dependent and is therefore now provided by our `Compiler` object.