### PR TITLE
Refactor eigenwave script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
     - export PYTHONPATH=`pwd`:$PYTHONPATH
     - flake8 opesci
     - flake8 tests
-    - python tests/eigenwave3d.py
+    - python tests/eigenwave3d.py default --execute --nthreads=4
+    - OMP_NUM_THREADS=4 tests/src/eigenwave3d
+    - python tests/eigenwave3d.py default --output
     - python tests/eigenwave3d.py read
-    - python tests/eigenwave3d.py vtk
-    - tests/src/eigenwave3d

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ cd tests/src
 ./eigenwave3d
 ```
 
+##### Automatic execution
+
+Opesci-FD also provides automatic compilation and execution that
+allows developers to test their code directly from the Python
+environment. To execute the above test case in parallel run:
+```
+python tests/eigenwave3d.py --compiler <cc> --execute --nthreads <nt>
+```
+where `<cc>` is either `g++` or `icpc` and `<nt>` is the number of
+threads to use during execution. For additional options please see:
+```
+python tests/eigenwave3d.py --help
+```
+
+##### Manual compilation
+
 The generated source file can also be compiled by hand using the
 provided CMake file:
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ locally. To get the latests updates for your local copy simply add
 run:
 ```
 git clone https://github.com/opesci/opesci-fd.git
+cd opesci-fd; pip install -r requirements.txt
 export PYTHONPATH=`pwd`:$PYTHONPATH
 python setup.py build_clib --build-clib=`pwd`
 ```

--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -33,10 +33,16 @@ class Compiler(object):
             logfile.write("Compiling: %s\n" % " ".join(cc))
             try:
                 subprocess.check_call(cc, stdout=logfile, stderr=logfile)
+            except OSError:
+                err = """OSError during compilation
+Please check if compiler exists: %s""" % self._cc
+                raise RuntimeError(err)
             except subprocess.CalledProcessError:
-                print "Compilation error with:", " ".join(cc)
-                print "Log file:", logfile.name
-                raise RuntimeError("Error during compilation")
+                err = """Error during compilation:
+Compilation command: %s
+Source file: %s
+Log file: %s""" % (" ".join(cc), src, logfile.name)
+                raise RuntimeError(err)
         print "Compiled:", outname
         return outname
 

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -54,7 +54,7 @@ class StaggeredGrid(Grid):
                      'velocity_loop', 'stress_bc', 'velocity_bc', 'output_step',
                      'define_convergence', 'converge_test', 'print_convergence']
 
-    _switches = ['omp', 'ivdep', 'simd', 'double', 'io', 'expand', 'eval_const',
+    _switches = ['omp', 'ivdep', 'simd', 'double', 'expand', 'eval_const',
                  'output_vts', 'converge']
 
     def __init__(self, dimension, domain_size=None, grid_size=None,
@@ -76,7 +76,6 @@ class StaggeredGrid(Grid):
         self.ivdep = ivdep
         self.simd = simd
         self.double = double
-        self.io = io
         self.expand = expand
         self.eval_const = eval_const
         self.real_t = 'double' if self.double else 'float'
@@ -125,6 +124,11 @@ class StaggeredGrid(Grid):
     @property
     def fields(self):
         return self.sfields + self.vfields
+
+    @property
+    def io(self):
+        """Flag whether to include I/O headers"""
+        return self.read or self.output_vts
 
     def set_accuracy(self, accuracy):
         """

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -1027,7 +1027,7 @@ class StaggeredGrid(Grid):
     @property
     def print_convergence(self):
         """Code fragment that prints convergence norms"""
-        return '\n'.join(['printf("%s %s", conv.%s_l2);' %
+        return '\n'.join(['printf("%s %s\\n", conv.%s_l2);' %
                           (ccode(f.label), '\t%.10f', ccode(f.label))
                           for f in self.fields])
 

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -52,6 +52,7 @@ ${define_constants}
 ${load_fields}
 
 ${converge_test}
+return 0;
 }
 
 int main(){

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -141,7 +141,7 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, output_vts=False, o_converge=T
     return grid
 
 
-def default(execute=False, nthreads=1, output=False):
+def default(compiler='g++', execute=False, nthreads=1, output=False):
     """Eigenwave test case on a unit cube grid (100 x 100 x 100)
     """
     domain_size = (1.0, 1.0, 1.0)
@@ -153,14 +153,14 @@ def default(execute=False, nthreads=1, output=False):
                        o_converge=True, omp=True, simd=False,
                        ivdep=True, filename=filename)
     grid.set_switches(output_vts=output)
-    grid.compile(filename, compiler='g++', shared=False)
+    grid.compile(filename, compiler=compiler, shared=False)
     if execute:
         # Test Python-based execution for the base test
-        grid.execute(filename, compiler='g++', nthreads=nthreads)
+        grid.execute(filename, compiler=compiler, nthreads=nthreads)
         grid.convergence()
 
 
-def read_data(execute=False, nthreads=1, output=False):
+def read_data(compiler='g++', execute=False, nthreads=1, output=False):
     """Test for model intialisation from input file
 
     Computes eigenwave on a unit cube grid (200 x 200 x 200)
@@ -175,10 +175,10 @@ def read_data(execute=False, nthreads=1, output=False):
                        filename=filename, rho_file='RHOhomogx200',
                        vp_file='VPhomogx200', vs_file='VShomogx200')
     grid.set_switches(output_vts=output)
-    grid.compile(filename, compiler='g++', shared=False)
+    grid.compile(filename, compiler=compiler, shared=False)
     if execute:
         # Test Python-based execution for the base test
-        grid.execute(filename, compiler='g++', nthreads=nthreads)
+        grid.execute(filename, compiler=compiler, nthreads=nthreads)
         grid.convergence()
 
 
@@ -249,6 +249,8 @@ converge:  Convergence test of the (2,4) scheme, which is 2nd order
                        formatter_class=RawTextHelpFormatter)
     p.add_argument('mode', choices=('default', 'read', 'converge', 'cx1'),
                    nargs='?', default='default', help=ModeHelp)
+    p.add_argument('-c', '--compiler', default='g++',
+                   help='C++ Compiler to use for model compilation, eg. g++ or icpc')
     p.add_argument('-x', '--execute', action='store_true', default=False,
                    help='Dynamically execute the generated model')
     p.add_argument('-n', '--nthreads', type=int, default=1,
@@ -260,9 +262,11 @@ converge:  Convergence test of the (2,4) scheme, which is 2nd order
     print "Eigenwave3D example (mode=%s)" % args.mode
 
     if args.mode == 'default':
-        default(execute=args.execute, nthreads=args.nthreads, output=args.output)
+        default(compiler=args.compiler, execute=args.execute,
+                nthreads=args.nthreads, output=args.output)
     elif args.mode == 'read':
-        read_data(execute=args.execute, nthreads=args.nthreads, output=args.output)
+        read_data(compiler=args.compiler, execute=args.execute,
+                  nthreads=args.nthreads, output=args.output)
     elif args.mode == 'converge':
         converge_test()
     elif args.mode == 'cx1':

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -7,7 +7,7 @@ _test_dir = path.join(path.dirname(__file__), "src")
 
 
 def eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
-                omp=True, simd=False, ivdep=True, io=False, double=False,
+                omp=True, simd=False, ivdep=True, double=False,
                 filename='test.cpp', read=False, expand=True, eval_const=True,
                 rho_file='', vp_file='', vs_file=''):
     """
@@ -27,7 +27,6 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
     default False (do not use simd)
     :param ivddp: switch for inserting #praga ivdep before inner loop
     default True (use ivdep)
-    :param io: switch for include io header files
     default False (not include vtk header files)
     :param double: switch for using double as real number variables
     default False (use float)
@@ -63,8 +62,8 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=True,
                          velocity_fields=[U, V, W])
     grid.set_time_step(dt, tmax)
 
-    grid.set_switches(omp=omp, simd=simd, ivdep=ivdep, io=io,
-                      double=double, expand=expand, eval_const=eval_const,
+    grid.set_switches(omp=omp, simd=simd, ivdep=ivdep, double=double,
+                      expand=expand, eval_const=eval_const,
                       output_vts=o_step, converge=o_converge)
 
     # define parameters
@@ -155,7 +154,7 @@ def default():
     filename = path.join(_test_dir, 'eigenwave3d.cpp')
     grid = eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False,
                        o_converge=True, omp=True, simd=False,
-                       ivdep=True, io=False, filename=filename)
+                       ivdep=True, filename=filename)
     grid.compile(filename, compiler='g++', shared=False)
 
     # Test Python-based execution for the base test
@@ -176,7 +175,7 @@ def default_vtk():
     filename = path.join(_test_dir, 'eigenwave3d_vtk.cpp')
     grid = eigenwave3d(domain_size, grid_size, dt, tmax, o_step=True,
                        o_converge=True, omp=True, simd=False,
-                       ivdep=True, io=True, filename=filename)
+                       ivdep=True, filename=filename)
     grid.compile(filename, compiler='g++', shared=False)
 
 
@@ -191,7 +190,7 @@ def read_data():
     tmax = 1.0
     filename = path.join(_test_dir, 'eigenwave3d_read.cpp')
     grid = eigenwave3d(domain_size, grid_size, dt, tmax, o_step=True, o_converge=False,
-                       omp=True, simd=False, ivdep=True, io=True, read=True,
+                       omp=True, simd=False, ivdep=True, read=True,
                        filename=filename, rho_file='RHOhomogx200',
                        vp_file='VPhomogx200', vs_file='VShomogx200')
     grid.compile(filename, compiler='g++', shared=False)
@@ -206,10 +205,10 @@ def cx1():
     dt = 0.001
     tmax = 5.0
     eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=False,
-                omp=True, simd=False, ivdep=True, io=False,
+                omp=True, simd=False, ivdep=True,
                 filename=path.join(_test_dir, 'eigenwave3d_ivdep.cpp'))
     eigenwave3d(domain_size, grid_size, dt, tmax, o_step=False, o_converge=False,
-                omp=True, simd=True, ivdep=False, io=False,
+                omp=True, simd=True, ivdep=False,
                 filename=path.join(_test_dir, 'eigenwave3d_simd.cpp'))
 
 
@@ -226,25 +225,25 @@ def converge_test():
     dt = c/(s**2)
     tmax = 5.0
     eigenwave3d(domain_size, (s, s, s), dt, tmax, o_step=False, o_converge=True,
-                omp=True, simd=False, ivdep=True, io=False,
+                omp=True, simd=False, ivdep=True,
                 filename='tmp/test3d_'+str(s)+'.cpp')
 
     s = s*2
     dt = c/(s**2)
     eigenwave3d(domain_size, (s, s, s), dt, tmax, o_step=False, o_converge=True,
-                omp=True, simd=False, ivdep=True, io=False,
+                omp=True, simd=False, ivdep=True,
                 filename='tmp/test3d_'+str(s)+'.cpp')
 
     s = s*2
     dt = c/(s**2)
     eigenwave3d(domain_size, (s, s, s), dt, tmax, o_step=False, o_converge=True,
-                omp=True, simd=False, ivdep=True, io=False,
+                omp=True, simd=False, ivdep=True,
                 filename='tmp/test3d_'+str(s)+'.cpp')
 
     s = s*2
     dt = c/(s**2)
     eigenwave3d(domain_size, (s, s, s), dt, tmax, o_step=False, o_converge=True,
-                omp=True, simd=False, ivdep=True, io=False,
+                omp=True, simd=False, ivdep=True,
                 filename='tmp/test3d_'+str(s)+'.cpp')
 
 

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -141,7 +141,7 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, output_vts=False, o_converge=T
     return grid
 
 
-def default(execute=False, output=False):
+def default(execute=False, nthreads=1, output=False):
     """Eigenwave test case on a unit cube grid (100 x 100 x 100)
     """
     domain_size = (1.0, 1.0, 1.0)
@@ -156,11 +156,11 @@ def default(execute=False, output=False):
     grid.compile(filename, compiler='g++', shared=False)
     if execute:
         # Test Python-based execution for the base test
-        grid.execute(filename, compiler='g++')
+        grid.execute(filename, compiler='g++', nthreads=nthreads)
         grid.convergence()
 
 
-def read_data(execute=False, output=False):
+def read_data(execute=False, nthreads=1, output=False):
     """Test for model intialisation from input file
 
     Computes eigenwave on a unit cube grid (200 x 200 x 200)
@@ -178,7 +178,7 @@ def read_data(execute=False, output=False):
     grid.compile(filename, compiler='g++', shared=False)
     if execute:
         # Test Python-based execution for the base test
-        grid.execute(filename, compiler='g++')
+        grid.execute(filename, compiler='g++', nthreads=nthreads)
         grid.convergence()
 
 
@@ -251,6 +251,8 @@ converge:  Convergence test of the (2,4) scheme, which is 2nd order
                    nargs='?', default='default', help=ModeHelp)
     p.add_argument('-x', '--execute', action='store_true', default=False,
                    help='Dynamically execute the generated model')
+    p.add_argument('-n', '--nthreads', type=int, default=1,
+                   help='Number of threads for dynamic execution')
     p.add_argument('-o', '--output', action='store_true', default=False,
                    help='Activate solution output in .vts format')
 
@@ -258,9 +260,9 @@ converge:  Convergence test of the (2,4) scheme, which is 2nd order
     print "Eigenwave3D example (mode=%s)" % args.mode
 
     if args.mode == 'default':
-        default(execute=args.execute, output=args.output)
+        default(execute=args.execute, nthreads=args.nthreads, output=args.output)
     elif args.mode == 'read':
-        read_data(execute=args.execute, output=args.output)
+        read_data(execute=args.execute, nthreads=args.nthreads, output=args.output)
     elif args.mode == 'converge':
         converge_test()
     elif args.mode == 'cx1':

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -1,6 +1,7 @@
 from opesci import *
 from os import path
-import sys
+from argparse import ArgumentParser, RawTextHelpFormatter
+
 
 _test_dir = path.join(path.dirname(__file__), "src")
 
@@ -248,29 +249,35 @@ def converge_test():
 
 
 def main():
-    if len(sys.argv) > 2:
-        print 'too many arguments!'
-        return
+    ModeHelp = """Avalable testing modes:
+default:   Eigenwave test case on a unit cube grid (100 x 100 x 100)
 
-    if len(sys.argv) == 1:
+read:      Test for model intialisation from input file; computes
+           eigenwave on a unit cube grid (200 x 200 x 200)
+
+converge:  Convergence test of the (2,4) scheme, which is 2nd order
+           in time and 4th order in space. The test halves spacing
+           starting from 0.1 and reduces dt by a factor of 4 for
+           each step
+"""
+    p = ArgumentParser(description="Standalone testing script for the Eigenwave3D example",
+                       formatter_class=RawTextHelpFormatter)
+    p.add_argument('mode', choices=('default', 'read', 'vtk', 'converge', 'cx1'),
+                   nargs='?', default='default', help=ModeHelp)
+
+    args = p.parse_args()
+    print "Eigenwave3D example (mode=%s)" % args.mode
+
+    if args.mode == 'default':
         default()
-        return
-
-    if sys.argv[1] == 'cx1':
-        cx1()
-        return
-
-    if sys.argv[1] == 'converge':
-        converge_test()
-        return
-
-    if sys.argv[1] == 'read':
+    elif args.mode == 'read':
         read_data()
-        return
-
-    if sys.argv[1] == 'vtk':
+    elif args.mode == 'vtk':
         default_vtk()
-        return
+    elif args.mode == 'converge':
+        converge_test()
+    elif args.mode == 'cx1':
+        cx1()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This merge refactors the eigenwave3d.py example script to provide a ncie and clean user interface, including automatic parallel execution and an optional flag for solution output. More specifically it includes:
* Automatic parallel execution that sets `OMP_NUM_PROCS` and the affinity at run-time
* Improved user interface for the eigenwave3d.py script through use of an ArgumentParser
* New flags for test script, including a compiler flag, run-time execution and an output flag
* Updated README entries for example script and dependency installation

Note, that this wants PR #32 to land first.