### PR TITLE
Automated PAPI profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ PROJECT(OPESCI)
 set (OPESCI_VERSION_MAJOR 0)
 set (OPESCI_VERSION_MINOR 1)
 
-set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/Modules ${CMAKE_MODULE_PATH})
+set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -49,6 +49,13 @@ find_package(OpenMP)
 if (OPENMP_FOUND)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     add_definitions(-DOPENMP_FOUND)
+endif()
+
+find_package(PAPI)
+if(PAPI_FOUND)
+  include_directories(${PAPI_INCLUDE_DIRS})
+  set (OPESCI_LIBRARIES ${PAPI_LIBRARIES} ${OPESCI_LIBRARIES})
+  add_definitions(-DOPESCI_HAVE_PAPI)
 endif()
 
 include_directories(include)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ For additional options please see:
 python tests/eigenwave3d.py --help
 ```
 
+##### Profiling
+
+If the PAPI library is found on your system during the initial build,
+Opesci-FD can also provide profiling information, such as the achieved
+number of MFlops/s during automated runs. To enable this feature
+simply add the `--profiling` flag to the example command above. The
+user can also supply a list of PAPI event names, for example
+`PAPI_TOT_CYC` or `PAPI_FP_OPS`, via the `--papi-events` flag:
+```
+python tests/eigenwave3d.py -c g++ -x --n 4 --profiling --papi-events PAPI_TOT_CYC PAPI_FP_OPS
+```
+
+Please note that the availability of PAPI events is highly dependent
+on the hardware you are running on and the local PAPI install.
+
 ##### Manual compilation
 
 The generated source file can also be compiled by hand using the

--- a/cmake/FindPAPI.cmake
+++ b/cmake/FindPAPI.cmake
@@ -1,0 +1,45 @@
+# Try to find PAPI headers and libraries.
+#
+# Usage of this module as follows:
+#
+#     find_package(PAPI)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  PAPI_PREFIX         Set this variable to the root installation of
+#                      libpapi if the module has problems finding the
+#                      proper installation path.
+#
+# Variables defined by this module:
+#
+#  PAPI_FOUND              System has PAPI libraries and headers
+#  PAPI_LIBRARIES          The PAPI library
+#  PAPI_INCLUDE_DIRS       The location of PAPI headers
+
+find_path(PAPI_PREFIX
+    NAMES include/papi.h
+)
+
+find_library(PAPI_LIBRARIES
+    # Pick the static library first for easier run-time linking.
+    NAMES libpapi.so papi
+    HINTS ${PAPI_PREFIX}/lib ${HILTIDEPS}/lib
+)
+
+find_path(PAPI_INCLUDE_DIRS
+    NAMES papi.h
+    HINTS ${PAPI_PREFIX}/include ${HILTIDEPS}/include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PAPI DEFAULT_MSG
+    PAPI_LIBRARIES
+    PAPI_INCLUDE_DIRS
+)
+
+mark_as_advanced(
+    PAPI_PREFIX_DIRS
+    PAPI_LIBRARIES
+    PAPI_INCLUDE_DIRS
+)

--- a/include/opesciProfiling.h
+++ b/include/opesciProfiling.h
@@ -1,0 +1,42 @@
+/*  Copyright (C) 2015 Imperial College London and others.
+ *
+ *  Please see the AUTHORS file in the main source directory for a
+ *  full list of copyright holders.
+ *
+ *  Gerard Gorman
+ *  Department of Earth Science and Engineering
+ *  Imperial College London
+ *
+ *  g.gorman@imperial.ac.uk
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above
+ *  copyright notice, this list of conditions and the following
+ *  disclaimer in the documentation and/or other materials provided
+ *  with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+ *  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ *  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ *  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE.
+ */
+#ifndef OPESCIPROFILING_H
+#define OPESCIPROFILING_H
+#include <cstdio>
+
+void opesci_flops(float*, float*, long long*, float*);
+
+#endif

--- a/include/opesciProfiling.h
+++ b/include/opesciProfiling.h
@@ -37,6 +37,7 @@
 #define OPESCIPROFILING_H
 #include <cstdio>
 
+int opesci_papi_init();
 void opesci_flops(float*, float*, long long*, float*);
 
 #endif

--- a/include/opesciProfiling.h
+++ b/include/opesciProfiling.h
@@ -40,4 +40,7 @@
 int opesci_papi_init();
 void opesci_flops(float*, float*, long long*, float*);
 
+int opesci_papi_name2event(char *, int*);
+int opesci_papi_start_counters(int, int*);
+int opesci_papi_read_counters(int, long long*);
 #endif

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -3,7 +3,7 @@ from codeprinter import ccode
 
 from StringIO import StringIO
 from mako.runtime import Context
-from ctypes import cdll, Structure, POINTER, c_float, pointer
+from ctypes import cdll, Structure, POINTER, c_float, pointer, c_longlong
 from os import environ
 
 
@@ -126,6 +126,7 @@ class Grid(object):
         # Define OpesciProfiling struct and generate "profiling" argument
         class OpesciProfiling(Structure):
             _fields_ = [(var, c_float) for var in ['rtime', 'ptime', 'mflops']]
+            _fields_ += [(ev, c_longlong) for ev in self._papi_events]
         self._arg_profiling = OpesciProfiling()
         self._arg_profiling.values = [0., 0., 0.]
 
@@ -137,6 +138,8 @@ class Grid(object):
         opesci_execute(pointer(self._arg_grid), pointer(self._arg_profiling))
 
         if self.profiling:
+            for ev in self._papi_events:
+                print "PAPI:: %s: %ld" % (ev, getattr(self._arg_profiling, ev))
             print "PAPI:: Max real_time: %f (sec)" % self._arg_profiling.rtime
             print "PAPI:: Max proc_time: %f (sec)" % self._arg_profiling.ptime
             print "PAPI:: Total MFlops/s: %f" % self._arg_profiling.mflops

--- a/opesci/grid.py
+++ b/opesci/grid.py
@@ -138,11 +138,13 @@ class Grid(object):
         opesci_execute(pointer(self._arg_grid), pointer(self._arg_profiling))
 
         if self.profiling:
-            for ev in self._papi_events:
-                print "PAPI:: %s: %ld" % (ev, getattr(self._arg_profiling, ev))
-            print "PAPI:: Max real_time: %f (sec)" % self._arg_profiling.rtime
-            print "PAPI:: Max proc_time: %f (sec)" % self._arg_profiling.ptime
-            print "PAPI:: Total MFlops/s: %f" % self._arg_profiling.mflops
+            if len(self._papi_events) > 0:
+                for ev in self._papi_events:
+                    print "PAPI:: %s: %ld" % (ev, getattr(self._arg_profiling, ev))
+            else:
+                print "PAPI:: Max real_time: %f (sec)" % self._arg_profiling.rtime
+                print "PAPI:: Max proc_time: %f (sec)" % self._arg_profiling.ptime
+                print "PAPI:: Total MFlops/s: %f" % self._arg_profiling.mflops
 
     def convergence(self):
         """Compute L2 norms for convergence testing"""

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -56,7 +56,8 @@ class StaggeredGrid(Grid):
                      'define_fields', 'store_fields', 'load_fields',
                      'initialise', 'initialise_bc', 'stress_loop',
                      'velocity_loop', 'stress_bc', 'velocity_bc', 'output_step',
-                     'define_convergence', 'converge_test', 'print_convergence']
+                     'define_convergence', 'converge_test', 'print_convergence',
+                     'define_profiling']
 
     _switches = ['omp', 'ivdep', 'simd', 'double', 'expand', 'eval_const',
                  'output_vts', 'converge', 'profiling']
@@ -1192,3 +1193,9 @@ class StaggeredGrid(Grid):
             result += 'conv->%s = %s;\n' % (l2, l2_value)
 
         return result
+
+    @property
+    def define_profiling(self):
+        """Code fragment that defines global PAPI counters and events"""
+        return '\n'.join('float g_%s = 0.0;' % v for v in
+                         ['rtime', 'ptime', 'mflops'])

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -47,22 +47,25 @@ class StaggeredGrid(Grid):
     * eval_const: evaluate all constants in kernel in generated code default True
     * output_vts: Output solution fields at every timestep
     * converge: Generate code for computing analutical solution and L2 norms
+    * profiling: Generate code for gathering profiling information via PAPI
     """
     template_base = 'staggered3d_tmpl.cpp'
 
-    template_keys = ['io', 'time_stepping', 'define_constants', 'declare_fields',
+    template_keys = ['io', 'profiling',
+                     'time_stepping', 'define_constants', 'declare_fields',
                      'define_fields', 'store_fields', 'load_fields',
                      'initialise', 'initialise_bc', 'stress_loop',
                      'velocity_loop', 'stress_bc', 'velocity_bc', 'output_step',
                      'define_convergence', 'converge_test', 'print_convergence']
 
     _switches = ['omp', 'ivdep', 'simd', 'double', 'expand', 'eval_const',
-                 'output_vts', 'converge']
+                 'output_vts', 'converge', 'profiling']
 
     def __init__(self, dimension, index=None, domain_size=None, grid_size=None,
                  time_step=None, stress_fields=None, velocity_fields=None,
                  omp=True, ivdep=True, simd=False, double=False, io=False,
-                 expand=True, eval_const=True, output_vts=False, converge=False):
+                 expand=True, eval_const=True, output_vts=False,
+                 converge=False, profiling=False):
         self.dimension = dimension
 
         template_dir = path.join(get_package_dir(), "templates")
@@ -83,6 +86,7 @@ class StaggeredGrid(Grid):
         self.real_t = 'double' if self.double else 'float'
         self.output_vts = output_vts
         self.converge = converge
+        self.profiling = profiling
 
         # number of ghost cells for boundary
         self.margin = Variable('margin', 2, 'int', True)

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -51,7 +51,7 @@ class StaggeredGrid(Grid):
     """
     template_base = 'staggered3d_tmpl.cpp'
 
-    template_keys = ['io', 'profiling',
+    template_keys = ['io', 'profiling', 'numevents_papi',
                      'time_stepping', 'define_constants', 'declare_fields',
                      'define_fields', 'store_fields', 'load_fields',
                      'initialise', 'initialise_bc', 'stress_loop',
@@ -1211,12 +1211,15 @@ class StaggeredGrid(Grid):
         return code
 
     @property
+    def numevents_papi(self):
+        return len(self._papi_events)
+
+    @property
     def define_papi_events(self):
         """Code fragment that starts PAPI counters for specified events"""
-        numevents = len(self._papi_events)
-        code = 'int numevents = %d;\n' % numevents
-        code += 'int events[%d];\n' % numevents
-        code += 'long long counters[%d];\n' % numevents
+        code = 'int numevents = %d;\n' % self.numevents_papi
+        code += 'int events[%d];\n' % self.numevents_papi
+        code += 'long long counters[%d];\n' % self.numevents_papi
         code += '\n'.join(['opesci_papi_name2event("%s", &(events[%d]));' % (e, i)
                           for i, e in enumerate(self._papi_events)])
         return code

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -42,6 +42,8 @@ float proc_time;
 float mflops;
 long long flpins;
 opesci_flops(&real_time, &proc_time, &flpins, &mflops);
+${define_papi_events}
+opesci_papi_start_counters(numevents, events);
 % endif
 
 ${initialise}
@@ -62,11 +64,13 @@ ${output_step}
 
 % if profiling==True:
 opesci_flops(&real_time, &proc_time, &flpins, &mflops);
+opesci_papi_read_counters(numevents, counters);
 #pragma omp critical
 {
 profiling->g_rtime = fmax(profiling->g_rtime, real_time);
 profiling->g_ptime = fmax(profiling->g_ptime, proc_time);
 profiling->g_mflops += mflops;
+${sum_papi_events}
 }
 % endif
 

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -6,6 +6,14 @@
 % if io==True:
 <%include file="io_include.txt"/>
 % endif
+% if profiling==True:
+#include "opesciProfiling.h"
+float real_time;
+float proc_time;
+float mflops;
+long long flpins;
+% endif
+
 #include <cmath>
 #include <cstdio>
 #include <string>
@@ -22,6 +30,10 @@ extern "C" int opesci_execute(OpesciGrid *grid) {
 
 ${define_constants}
 ${declare_fields}
+
+% if profiling==True:
+opesci_flops(&real_time, &proc_time, &flpins, &mflops);
+% endif
 
 #pragma omp parallel
 {
@@ -43,6 +55,14 @@ ${output_step}
 } // end of parallel section
 
 ${store_fields}
+
+% if profiling==True:
+opesci_flops(&real_time, &proc_time, &flpins, &mflops);
+printf("PAPI:: Total Flops:\n");
+printf("PAPI:: Total rtime: %f (sec)\n", (real_time));
+printf("PAPI:: Total ptime: %f (sec)\n", (proc_time));
+printf("PAPI:: MFlops/s: %f\n", mflops);
+% endif
 
 return 0;
 }

--- a/opesci/templates/staggered/staggered3d_tmpl.cpp
+++ b/opesci/templates/staggered/staggered3d_tmpl.cpp
@@ -43,7 +43,9 @@ float mflops;
 long long flpins;
 opesci_flops(&real_time, &proc_time, &flpins, &mflops);
 ${define_papi_events}
+% if numevents_papi>0:
 opesci_papi_start_counters(numevents, events);
+% endif
 % endif
 
 ${initialise}
@@ -64,7 +66,9 @@ ${output_step}
 
 % if profiling==True:
 opesci_flops(&real_time, &proc_time, &flpins, &mflops);
+% if numevents_papi>0:
 opesci_papi_read_counters(numevents, counters);
+% endif
 #pragma omp critical
 {
 profiling->g_rtime = fmax(profiling->g_rtime, real_time);

--- a/src/opesciProfiling.cpp
+++ b/src/opesciProfiling.cpp
@@ -37,12 +37,30 @@
 #if defined(OPESCI_HAVE_PAPI)
 #include "papi.h"
 #endif
+#include "omp.h"
+
+#define OPESCI_PAPI_WARN "WARNING:: PAPI error: Flops/s counters are not reliable!\n"
+#define OPESCI_PAPI_MISSING "WARNING:: PAPI not found: Please re-build Opesci-FD with PAPI libraries\n"
+
+int opesci_papi_init() {
+#if defined(OPESCI_HAVE_PAPI)
+  int err, version;
+  version = PAPI_library_init(PAPI_VER_CURRENT);
+  if (version != PAPI_VER_CURRENT) printf(OPESCI_PAPI_WARN);
+
+  err = PAPI_thread_init((unsigned long (*)()) omp_get_thread_num);
+  if (err != PAPI_OK) printf(OPESCI_PAPI_WARN);
+  return err;
+#else
+  printf(OPESCI_PAPI_MISSING);
+#endif
+}
 
 void opesci_flops(float *rtime, float *ptime, long long *flpins, float *mflops) {
 #if defined(OPESCI_HAVE_PAPI)
   int err = PAPI_flops(rtime, ptime, flpins, mflops);
-  if (err != PAPI_OK) printf("WARNING: PAPI error: Flops/s counters are not reliable!\n");
+  if (err != PAPI_OK) printf(OPESCI_PAPI_WARN);
 #else
-  printf("WARNING:: PAPI not found: Please re-build Opesci-FD with PAPI libraries\n");
+  printf(OPESCI_PAPI_MISSING);
 #endif
 }

--- a/src/opesciProfiling.cpp
+++ b/src/opesciProfiling.cpp
@@ -63,7 +63,7 @@ int opesci_papi_start_counters(int numevents, int *events) {
     printf(OPESCI_PAPI_WARN);
   }
   int err = PAPI_start_counters(events, numevents);
-  if (err != PAPI_OK) printf(OPESCI_PAPI_WARN);
+  if (err != PAPI_OK && omp_get_thread_num()==0) printf(OPESCI_PAPI_WARN);
 #else
   printf(OPESCI_PAPI_MISSING);
 #endif
@@ -80,7 +80,7 @@ int opesci_papi_name2event(char *name, int *event) {
 int opesci_papi_read_counters(int numevents, long long *counters) {
 #if defined(OPESCI_HAVE_PAPI)
   int err = PAPI_read_counters(counters, numevents);
-  if (err != PAPI_OK) printf(OPESCI_PAPI_WARN);
+  if (err != PAPI_OK && omp_get_thread_num()==0) printf(OPESCI_PAPI_WARN);
 #else
   printf(OPESCI_PAPI_MISSING);
 #endif
@@ -89,7 +89,7 @@ int opesci_papi_read_counters(int numevents, long long *counters) {
 void opesci_flops(float *rtime, float *ptime, long long *flpins, float *mflops) {
 #if defined(OPESCI_HAVE_PAPI)
   int err = PAPI_flops(rtime, ptime, flpins, mflops);
-  if (err != PAPI_OK) printf(OPESCI_PAPI_WARN);
+  if (err != PAPI_OK && omp_get_thread_num()==0) printf(OPESCI_PAPI_WARN);
 #else
   printf(OPESCI_PAPI_MISSING);
 #endif

--- a/src/opesciProfiling.cpp
+++ b/src/opesciProfiling.cpp
@@ -1,0 +1,48 @@
+/*  Copyright (C) 2015 Imperial College London and others.
+ *
+ *  Please see the AUTHORS file in the main source directory for a
+ *  full list of copyright holders.
+ *
+ *  Gerard Gorman
+ *  Department of Earth Science and Engineering
+ *  Imperial College London
+ *
+ *  g.gorman@imperial.ac.uk
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above
+ *  copyright notice, this list of conditions and the following
+ *  disclaimer in the documentation and/or other materials provided
+ *  with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+ *  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ *  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ *  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE.
+ */
+#include "opesciProfiling.h"
+#if defined(OPESCI_HAVE_PAPI)
+#include "papi.h"
+#endif
+
+void opesci_flops(float *rtime, float *ptime, long long *flpins, float *mflops) {
+#if defined(OPESCI_HAVE_PAPI)
+  int err = PAPI_flops(rtime, ptime, flpins, mflops);
+  if (err != PAPI_OK) printf("WARNING: PAPI error: Flops/s counters are not reliable!\n");
+#else
+  printf("WARNING:: PAPI not found: Please re-build Opesci-FD with PAPI libraries\n");
+#endif
+}

--- a/src/opesciProfiling.cpp
+++ b/src/opesciProfiling.cpp
@@ -56,6 +56,36 @@ int opesci_papi_init() {
 #endif
 }
 
+int opesci_papi_start_counters(int numevents, int *events) {
+#if defined(OPESCI_HAVE_PAPI)
+  if (PAPI_num_counters() < numevents) {
+    printf("WARNING: More events specified that hardware counters available\n");
+    printf(OPESCI_PAPI_WARN);
+  }
+  int err = PAPI_start_counters(events, numevents);
+  if (err != PAPI_OK) printf(OPESCI_PAPI_WARN);
+#else
+  printf(OPESCI_PAPI_MISSING);
+#endif
+}
+
+int opesci_papi_name2event(char *name, int *event) {
+#if defined(OPESCI_HAVE_PAPI)
+  return PAPI_event_name_to_code(name, event);
+#else
+  printf(OPESCI_PAPI_MISSING);
+#endif
+}
+
+int opesci_papi_read_counters(int numevents, long long *counters) {
+#if defined(OPESCI_HAVE_PAPI)
+  int err = PAPI_read_counters(counters, numevents);
+  if (err != PAPI_OK) printf(OPESCI_PAPI_WARN);
+#else
+  printf(OPESCI_PAPI_MISSING);
+#endif
+}
+
 void opesci_flops(float *rtime, float *ptime, long long *flpins, float *mflops) {
 #if defined(OPESCI_HAVE_PAPI)
   int err = PAPI_flops(rtime, ptime, flpins, mflops);

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -128,7 +128,8 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, output_vts=False, o_converge=T
     return grid
 
 
-def default(compiler=None, execute=False, nthreads=1, output=False):
+def default(compiler=None, execute=False, nthreads=1,
+            output=False, profiling=False):
     """Eigenwave test case on a unit cube grid (100 x 100 x 100)
     """
     domain_size = (1.0, 1.0, 1.0)
@@ -139,7 +140,7 @@ def default(compiler=None, execute=False, nthreads=1, output=False):
     grid = eigenwave3d(domain_size, grid_size, dt, tmax,
                        o_converge=True, omp=True, simd=False,
                        ivdep=True, filename=filename)
-    grid.set_switches(output_vts=output)
+    grid.set_switches(output_vts=output, profiling=profiling)
     if compiler is None:
         grid.generate(filename)
     else:
@@ -150,7 +151,8 @@ def default(compiler=None, execute=False, nthreads=1, output=False):
         grid.convergence()
 
 
-def read_data(compiler=None, execute=False, nthreads=1, output=False):
+def read_data(compiler=None, execute=False, nthreads=1,
+              output=False, profiling=False):
     """Test for model intialisation from input file
 
     Computes eigenwave on a unit cube grid (200 x 200 x 200)
@@ -164,7 +166,7 @@ def read_data(compiler=None, execute=False, nthreads=1, output=False):
                        o_converge=False, omp=True, simd=False, ivdep=True,
                        filename=filename, rho_file='RHOhomogx200',
                        vp_file='VPhomogx200', vs_file='VShomogx200')
-    grid.set_switches(output_vts=output)
+    grid.set_switches(output_vts=output, profiling=profiling)
     if compiler is None:
         grid.generate(filename)
     else:
@@ -250,16 +252,20 @@ converge:  Convergence test of the (2,4) scheme, which is 2nd order
                    help='Number of threads for dynamic execution')
     p.add_argument('-o', '--output', action='store_true', default=False,
                    help='Activate solution output in .vts format')
+    p.add_argument('-p', '--profiling', action='store_true', default=False,
+                   help='Activate performance profiling from PAPI')
 
     args = p.parse_args()
     print "Eigenwave3D example (mode=%s)" % args.mode
 
     if args.mode == 'default':
         default(compiler=args.compiler, execute=args.execute,
-                nthreads=args.nthreads, output=args.output)
+                nthreads=args.nthreads, output=args.output,
+                profiling=args.profiling)
     elif args.mode == 'read':
         read_data(compiler=args.compiler, execute=args.execute,
-                  nthreads=args.nthreads, output=args.output)
+                  nthreads=args.nthreads, output=args.output,
+                  profiling=args.profiling)
     elif args.mode == 'converge':
         converge_test()
     elif args.mode == 'cx1':

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -129,7 +129,7 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, output_vts=False, o_converge=T
 
 
 def default(compiler=None, execute=False, nthreads=1,
-            output=False, profiling=False):
+            output=False, profiling=False, papi_events=[]):
     """Eigenwave test case on a unit cube grid (100 x 100 x 100)
     """
     domain_size = (1.0, 1.0, 1.0)
@@ -141,6 +141,7 @@ def default(compiler=None, execute=False, nthreads=1,
                        o_converge=True, omp=True, simd=False,
                        ivdep=True, filename=filename)
     grid.set_switches(output_vts=output, profiling=profiling)
+    grid.set_papi_events(papi_events)
     if compiler is None:
         grid.generate(filename)
     else:
@@ -152,7 +153,7 @@ def default(compiler=None, execute=False, nthreads=1,
 
 
 def read_data(compiler=None, execute=False, nthreads=1,
-              output=False, profiling=False):
+              output=False, profiling=False, papi_events=[]):
     """Test for model intialisation from input file
 
     Computes eigenwave on a unit cube grid (200 x 200 x 200)
@@ -167,6 +168,7 @@ def read_data(compiler=None, execute=False, nthreads=1,
                        filename=filename, rho_file='RHOhomogx200',
                        vp_file='VPhomogx200', vs_file='VShomogx200')
     grid.set_switches(output_vts=output, profiling=profiling)
+    grid.set_papi_events(papi_events)
     if compiler is None:
         grid.generate(filename)
     else:
@@ -254,6 +256,8 @@ converge:  Convergence test of the (2,4) scheme, which is 2nd order
                    help='Activate solution output in .vts format')
     p.add_argument('-p', '--profiling', action='store_true', default=False,
                    help='Activate performance profiling from PAPI')
+    p.add_argument('--papi-events', dest='papi_events', nargs='+', default=[],
+                   help='Specific PAPI events to measure')
 
     args = p.parse_args()
     print "Eigenwave3D example (mode=%s)" % args.mode
@@ -261,11 +265,11 @@ converge:  Convergence test of the (2,4) scheme, which is 2nd order
     if args.mode == 'default':
         default(compiler=args.compiler, execute=args.execute,
                 nthreads=args.nthreads, output=args.output,
-                profiling=args.profiling)
+                profiling=args.profiling, papi_events=args.papi_events)
     elif args.mode == 'read':
         read_data(compiler=args.compiler, execute=args.execute,
                   nthreads=args.nthreads, output=args.output,
-                  profiling=args.profiling)
+                  profiling=args.profiling, papi_events=args.papi_events)
     elif args.mode == 'converge':
         converge_test()
     elif args.mode == 'cx1':


### PR DESCRIPTION
This merge adds PAPI-based automated profiling capabilities. Specifically it adds two new flags to the example test scripts:
* `--profiling` will add wrapped calls to `PAPI_flops()` and output measured times and MFlops/s rates at the end of automatic runs
* `--papi-events` allows users to specify PAPI event names on the command line that will be measured and output in addition to the Flops/s counters. 