### PR TITLE
Clang: Use Intel OpenMP flag with Clang to fix auto-compilation

### DIFF
--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -74,7 +74,7 @@ class ClangCompiler(Compiler):
     """
 
     def __init__(self, cppargs=[], ldargs=[]):
-        opt_flags = ['-g', '-O3', '-fopenmp']
+        opt_flags = ['-g', '-O3', '-openmp']
         cppargs = ['-Wall', '-std=c++11', '-I%s/include' % get_package_dir()] + opt_flags + cppargs
         ldargs = ['-lopesci', '-Wl,-rpath,%s/lib' % get_package_dir(),
                   '-L%s/lib' % get_package_dir()] + ldargs


### PR DESCRIPTION
Small fix to get auto-compilation working on Macs.