### PR TITLE
cmake error fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,30 @@ language: python
 python:
     - "2.7"
 
-before_install:
-    - sudo apt-get install texinfo
-    - sudo apt-get install  libgmp3-dev
-    - wget http://sourceforge.net/projects/pluto-compiler/files/pluto-0.11.3.tar.gz
-    - tar zxvf pluto-0.11.3.tar.gz
-    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libvtk5-dev libvtk5.8
-    - sudo apt-get install -qq gcc-4.8 g++-4.8
-    - sudo apt-get install clang
+sudo: required
+
+addons:
+  apt:
+    sources:
+     - ubuntu-toolchain-r-test
+    packages:
+     - texinfo
+     - libgmp3-dev
+     - libvtk5-dev
+     - libvtk5.8
+     - gcc-4.8
+     - g++-4.8
+     - clang
 
 install:
+    - wget http://sourceforge.net/projects/pluto-compiler/files/pluto-0.11.3.tar.gz
+    - tar zxvf pluto-0.11.3.tar.gz
     - cd pluto-0.11.3
     - ./configure
     - make -j4
     - chmod +x polycc
     - export PATH=$PATH:`pwd`
+    - export CXX="g++-4.8"
     - cd ..
     - pip install --upgrade pip
     - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Difference models from a high-level description of the model
 equations. It allows the rapid development, analysis and optimisation
 of propagator codes for use in seismic imaging.
 
-### Dependencies
+## Dependencies
 
 Before installation, ensure that all the dependencies specified in the `requirements.txt` file are installed, using
 
@@ -19,7 +19,7 @@ In addition, CMake must also be installed. This can either be done using
 
 or by [building CMake from source](https://cmake.org/install/).
 
-### Installation
+## Installation
 
 Opesci-FD can be installed with:
 ```
@@ -36,7 +36,7 @@ export PYTHONPATH=`pwd`:$PYTHONPATH
 python setup.py build_clib --build-clib=`pwd`
 ```
 
-### Getting started
+## Getting started
 
 An example of the high-level model description is provided under
 `tests/eigenwave3d.py`. This script generates a stencil code that
@@ -51,7 +51,7 @@ This will generate the mode source code in `tests/src/eigenwave3d.cpp`.
 The source code can be compiled and executed either manually or 
 automatically.
 
-##### Automatic compilation and execution
+#### Automatic compilation and execution
 
 Opesci-FD provides automatic compilation and execution that allows 
 developers to test their code directly from the Python environment. 
@@ -72,7 +72,7 @@ For additional options please see:
 python tests/eigenwave3d.py --help
 ```
 
-##### Profiling
+#### Profiling
 
 If the PAPI library is found on your system during the initial build,
 Opesci-FD can also provide profiling information, such as the achieved
@@ -87,7 +87,7 @@ python tests/eigenwave3d.py -c g++ -x --n 4 --profiling --papi-events PAPI_TOT_C
 Please note that the availability of PAPI events is highly dependent
 on the hardware you are running on and the local PAPI install.
 
-##### Manual compilation
+#### Manual compilation
 
 The generated source file can also be compiled by hand using the
 provided CMake file:
@@ -107,7 +107,7 @@ controlling model input, the data type used (single of double
 precision or explicit vectorisation are also provided.
 
 
-##### Auto-tuning for pluto
+#### Auto-tuning for pluto
 
 Here is a script to test the best tile size to get the best optimisation effect:
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ Difference models from a high-level description of the model
 equations. It allows the rapid development, analysis and optimisation
 of propagator codes for use in seismic imaging.
 
+### Dependencies
+
+Before installation, ensure that all the dependencies specified in the `requirements.txt` file are installed, using
+
+```
+pip install -r requirements.txt
+```
+
+In addition, CMake must also be installed. This can either be done using
+
+```sudo apt-get install cmake```
+
+or by [building CMake from source](https://cmake.org/install/).
+
 ### Installation
 
 Opesci-FD can be installed with:
@@ -17,7 +31,7 @@ locally. To get the latest updates for your local copy simply add
 run:
 ```
 git clone https://github.com/opesci/opesci-fd.git
-cd opesci-fd; pip install -r requirements.txt
+cd opesci-fd
 export PYTHONPATH=`pwd`:$PYTHONPATH
 python setup.py build_clib --build-clib=`pwd`
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Opesci-FD
 
+[![Build Status](https://travis-ci.org/opesci/opesci-fd.svg?branch=master)](https://travis-ci.org/opesci/opesci-fd)
+
 Opesci-FD is a software package to automatically generate Finite
 Difference models from a high-level description of the model
 equations. It allows the rapid development, analysis and optimisation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Opesci-FD can be installed with:
 pip install --local git+https://github.com/opesci/opesci-fd.git
 ```
 This will install the latest version of the `opesci` python package
-locally. To get the latests updates for your local copy simply add
+locally. To get the latest updates for your local copy simply add
 `--upgrade` to the above command. For a developer checkout of the code
 run:
 ```
@@ -41,13 +41,13 @@ automatically.
 
 Opesci-FD provides automatic compilation and execution that allows 
 developers to test their code directly from the Python environment. 
-To compile the generted souce code:
+To compile the generated source code:
 ```
 python tests/eigenwave3d.py --compiler <cc>
 ```
 where `<cc>` is either `g++`,`clang` or `icpc`, indicating which compiler to
-use.Make sure your [clang](http://clang-omp.github.io/) compiler support openmp 
-for multithreads program.
+use. Make sure your [clang](http://clang-omp.github.io/) compiler supports openmp 
+for multithreaded execution.
 To compile and execute the above test case in parallel run:
 ```
 python tests/eigenwave3d.py --compiler <cc> --execute --nthreads <nt>

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ class CMakeBuilder(build_clib):
         # Run cmake and make in temp dir
         self.mkpath(build_dir)
         chdir(build_dir)
-        cmake_cmd = ["cmake", root_dir]
-        if subprocess.call(cmake_cmd) != 0:
-            raise EnvironmentError("error calling cmake")
+        cmake_cmd = "cmake %s" % root_dir
+        if subprocess.call(cmake_cmd, shell=True) != 0:
+            raise EnvironmentError("Error calling cmake. Check that it's installed? Check the path provided to the Opesci-FD root directory?")
 
         if subprocess.call("make") != 0:
-            raise EnvironmentError("error calling make")
+            raise EnvironmentError("Error calling make")
         chdir(root_dir)
 
         # Copy lib and include directories to opesci package


### PR DESCRIPTION
Correct various typos and formatting issues in `README.md`, and actually raise an exception when cmake does not exist. Addresses #50 and #55.