### PR TITLE
Travis container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ install:
     - make -j4
     - chmod +x polycc
     - export PATH=$PATH:`pwd`
-    - export CC="g++-4.8"
     - export CXX="g++-4.8"
+    - export CC="g++-4.8"
     - cd ..
     - pip install --upgrade pip
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - make -j4
     - chmod +x polycc
     - export PATH=$PATH:`pwd`
-    - export GCCVERSION=4.8
+    - export GCC_VERSION=4.8
     - export CXX="g++-4.8"
     - cd ..
     - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ install:
     - chmod +x polycc
     - export PATH=$PATH:`pwd`
     - export CXX="g++-4.8"
-    - export CC="g++-4.8"
     - cd ..
     - pip install --upgrade pip
     - pip install -r requirements.txt
@@ -36,6 +35,7 @@ script:
     - export PYTHONPATH=`pwd`:$PYTHONPATH
     - flake8 opesci
     - flake8 tests
+    - export CC="g++-4.8"
     - python tests/eigenwave3d.py default --compiler=g++ --execute --nthreads=4
     - OMP_NUM_THREADS=4 tests/src/eigenwave3d
     - python tests/eigenwave3d.py default --compiler=g++ --output

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - make -j4
     - chmod +x polycc
     - export PATH=$PATH:`pwd`
-    - export GCC_VERSION=4.8
+    - export CC="g++-4.8"
     - export CXX="g++-4.8"
     - cd ..
     - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
     - "2.7"
 
-sudo: required
+sudo: false
 
 addons:
   apt:
@@ -25,11 +25,11 @@ install:
     - make -j4
     - chmod +x polycc
     - export PATH=$PATH:`pwd`
+    - export GCCVERSION=4.8
     - export CXX="g++-4.8"
     - cd ..
     - pip install --upgrade pip
     - pip install -r requirements.txt
-    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
     - python setup.py build_clib --build-clib=`pwd`
 
 script:

--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -58,6 +58,15 @@ class GNUCompiler(Compiler):
         cppargs = ['-Wall', '-std=c++11', '-I%s/include' % get_package_dir()] + opt_flags + cppargs
         ldargs = ['-lopesci', '-Wl,-rpath,%s/lib' % get_package_dir(),
                   '-L%s/lib' % get_package_dir()] + ldargs
+
+        # Check if the g++ version is set in the GCCVERSION environment variable. If it is,
+        # then adds the sufix of the version to the g++, and puts it in the CC variable.
+        # i.e. GCCVERSION=4.8 then CC = g++-4.8
+        gccVersion = environ.get('GCCVERSION')
+	
+        if gccVersion:
+            environ['CC'] = 'g++-' + gccVersion
+
         super(GNUCompiler, self).__init__("g++", cppargs=cppargs, ldargs=ldargs)
 
     @property

--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -62,7 +62,7 @@ class GNUCompiler(Compiler):
         # Check if the g++ version is set in the GCCVERSION environment variable. If it is,
         # then adds the sufix of the version to the g++, and puts it in the CC variable.
         # i.e. GCCVERSION=4.8 then CC = g++-4.8
-        gccVersion = environ.get('GCCVERSION')
+        gccVersion = environ.get('GCC_VERSION')
 
         if gccVersion:
             environ['CC'] = 'g++-' + gccVersion

--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -63,7 +63,7 @@ class GNUCompiler(Compiler):
         # then adds the sufix of the version to the g++, and puts it in the CC variable.
         # i.e. GCCVERSION=4.8 then CC = g++-4.8
         gccVersion = environ.get('GCCVERSION')
-	
+
         if gccVersion:
             environ['CC'] = 'g++-' + gccVersion
 

--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -58,15 +58,6 @@ class GNUCompiler(Compiler):
         cppargs = ['-Wall', '-std=c++11', '-I%s/include' % get_package_dir()] + opt_flags + cppargs
         ldargs = ['-lopesci', '-Wl,-rpath,%s/lib' % get_package_dir(),
                   '-L%s/lib' % get_package_dir()] + ldargs
-
-        # Check if the g++ version is set in the GCCVERSION environment variable. If it is,
-        # then adds the sufix of the version to the g++, and puts it in the CC variable.
-        # i.e. GCCVERSION=4.8 then CC = g++-4.8
-        gccVersion = environ.get('GCC_VERSION')
-
-        if gccVersion:
-            environ['CC'] = 'g++-' + gccVersion
-
         super(GNUCompiler, self).__init__("g++", cppargs=cppargs, ldargs=ldargs)
 
     @property


### PR DESCRIPTION
Changes were made so we can use the container based travis build. Basically we needed something to specify which g++ version to use, because the default version of gcc in the image is 4.6 and our generated code is not compliant to it.
Now the user can specify a GCCVERSION environment variable, that will be used as suffix in the g++ executable, thus is able to compile on travis, without the need of SUDO to change the symbolic link.
Not using sudo is a requirement to be able to use container based travis.