### PR TITLE
In-memory AST for generated C source code

### DIFF
--- a/opesci/cgen_wrapper.py
+++ b/opesci/cgen_wrapper.py
@@ -1,18 +1,28 @@
 from cgen import *
 
 
-
 class IfDef(Module):
+    """
+    Class to represent IfDef-Else-EndIf construct for the C preprocessor.
+    While Cgen has classes for #define, #include, #pragma etc., it has nothing for IfDef.
+    :param condition: the condition in IfDef
+    :param iflines: the block of code inside the if [an array of type Generable]
+    :param elselines: the block of code inside the else [an array of type Generable]
+    """
     def __init__(self, condition, iflines, elselines):
-        
-        ifdef_line = Line('#ifdef %s'%condition)
+        ifdef_line = Line('#ifdef %s' % condition)
         else_line = Line('#else')
         endif_line = Line('#endif')
         lines = [ifdef_line]+iflines+[else_line]+elselines+[endif_line]
-        
         super(IfDef, self).__init__(lines)
 
+
 class InlineInitializer(Initializer):
+    """
+    Class to represent Initializers (int i=0) without the semicolon in the end(e.g. in a for statement)
+    Usage: same as cgen.Initializer
+    Result: same as cgen.Initializer except for the lack of a semi-colon at the end
+    """
     def generate(self):
         result = super(InlineInitializer, self).generate()
         for v in result:
@@ -21,19 +31,25 @@ class InlineInitializer(Initializer):
             else:
                 yield v
 
+
 def replace_in_code(code, str_from, str_to):
+    """
+    Helper function to find and replace strings inside code blocks
+    :param code: The code block in which to carry out the find/replace. This can be array of Generables or a Block or a Loop
+    :param str_from: The string to find (and to be replaced)
+    :param str_to: The string to replace all instances of str_from with
+    """
     if isinstance(code, Block):
         replace_in_code(code.contents, str_from, str_to)
         return code
-    if isinstance(code,Loop):
+    if isinstance(code, Loop):
         replace_in_code(code.body, str_from, str_to)
         return code
     for code_element in code:
-        if isinstance(code_element, Statement) or isinstance(code_element,Line):
+        if isinstance(code_element, Statement) or isinstance(code_element, Line):
             code_element.text.replace(str_from, str_to)
         if isinstance(code_element, Block):
             replace_in_code(code_element.contents, str_from, str_to)
         if isinstance(code_element, Loop):
             replace_in_code(code_element.body, str_from, str_to)
     return code
-        

--- a/opesci/cgen_wrapper.py
+++ b/opesci/cgen_wrapper.py
@@ -1,0 +1,39 @@
+from cgen import *
+
+
+
+class IfDef(Module):
+    def __init__(self, condition, iflines, elselines):
+        
+        ifdef_line = Line('#ifdef %s'%condition)
+        else_line = Line('#else')
+        endif_line = Line('#endif')
+        lines = [ifdef_line]+iflines+[else_line]+elselines+[endif_line]
+        
+        super(IfDef, self).__init__(lines)
+
+class InlineInitializer(Initializer):
+    def generate(self):
+        result = super(InlineInitializer, self).generate()
+        for v in result:
+            if v.endswith(';'):
+                yield v[:-1]
+            else:
+                yield v
+
+def replace_in_code(code, str_from, str_to):
+    if isinstance(code, Block):
+        replace_in_code(code.contents, str_from, str_to)
+        return code
+    if isinstance(code,Loop):
+        replace_in_code(code.body, str_from, str_to)
+        return code
+    for code_element in code:
+        if isinstance(code_element, Statement) or isinstance(code_element,Line):
+            code_element.text.replace(str_from, str_to)
+        if isinstance(code_element, Block):
+            replace_in_code(code_element.contents, str_from, str_to)
+        if isinstance(code_element, Loop):
+            replace_in_code(code_element.body, str_from, str_to)
+    return code
+        

--- a/opesci/compilation.py
+++ b/opesci/compilation.py
@@ -1,5 +1,6 @@
 from os import path, environ
 import subprocess
+import cgen_wrapper as cgen
 
 
 def get_package_dir():
@@ -62,7 +63,7 @@ class GNUCompiler(Compiler):
 
     @property
     def _ivdep(self):
-        return '#pragma GCC ivdep'
+        return cgen.Pragma('GCC ivdep')
 
 
 class ClangCompiler(Compiler):
@@ -82,7 +83,7 @@ class ClangCompiler(Compiler):
 
     @property
     def _ivdep(self):
-        return '#pragma ivdep'
+        return cgen.Pragma('ivdep')
 
 
 class IntelCompiler(Compiler):
@@ -100,4 +101,4 @@ class IntelCompiler(Compiler):
 
     @property
     def _ivdep(self):
-        return '#pragma ivdep'
+        return cgen.Pragma('ivdep')

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -1016,7 +1016,7 @@ class StaggeredGrid(Grid):
             body.append(cgen.Assign(ccode(field[idx]), ccode(kernel.xreplace({self.t+1: self.time[1], self.t: self.time[0]}))))
         body = [cgen.For(cgen.InlineInitializer(cgen.Value('int', indexes[1]), indexes[2]), cgen.Line('%s<%s' % (indexes[1], indexes[3])), cgen.Line('++%s' % indexes[1]), cgen.Block(body))]
         if not self.pluto and self.ivdep and indexes[0] == self.dimension-1:
-            body.insert(0, cgen.Statement(self.compiler._ivdep))
+            body.insert(0, self.compiler._ivdep)
         if not self.pluto and self.simd and indexes[0] == self.dimension-1:
             body.insert(0, cgen.Pragma('simd'))
 
@@ -1060,7 +1060,7 @@ class StaggeredGrid(Grid):
                     body_tmp = [cgen.Statement(ccode(field[idx]) + operator[operator_idx] + ccode(kernel_stmt_neg.xreplace({self.t+1: self.time[1], self.t: self.time[0]})))]
                     body_tmp = [cgen.For(cgen.InlineInitializer(cgen.Value('int', indexes[1]), indexes[2]), cgen.Line('%s<%s' % (indexes[1], indexes[3])), cgen.Line('++%s' % indexes[1]), cgen.Block(body_tmp))]
                     if not self.pluto and self.ivdep and indexes[0] == self.dimension-1:
-                        body_tmp.insert(0, cgen.Statement(self.compiler._ivdep))
+                        body_tmp.insert(0, self.compiler._ivdep)
                     if not self.pluto and self.simd and indexes[0] == self.dimension-1:
                         body_tmp.insert(0, cgen.Pragma('simd'))
                     body = body + body_tmp
@@ -1070,7 +1070,7 @@ class StaggeredGrid(Grid):
                     body_tmp = [cgen.Statement(ccode(field[idx]) + operator[operator_idx] + ccode(kernel_stmt_pos.xreplace({self.t+1: self.time[1], self.t: self.time[0]})))]
                     body_tmp = [cgen.For(cgen.InlineInitializer(cgen.Value('int', indexes[1]), indexes[2]), cgen.Line('%s<%s' % (indexes[1], indexes[3])), cgen.Line('++%s' % indexes[1]), cgen.Block(body_tmp))]
                     if not self.pluto and self.ivdep and indexes[0] == self.dimension-1:
-                        body_tmp.insert(0, cgen.Statement(self.compiler._ivdep))
+                        body_tmp.insert(0, self.compiler._ivdep)
                     if not self.pluto and self.simd and indexes[0] == self.dimension-1:
                         body_tmp.insert(0, cgen.Pragma('simd'))
                     body = body + body_tmp
@@ -1082,7 +1082,7 @@ class StaggeredGrid(Grid):
             body_tmp = [cgen.Statement(ccode(field[idx]) + '+=' + ccode(kernel_stmt.xreplace({self.t+1: self.time[1], self.t: self.time[0]})))]
             body_tmp = [cgen.For(cgen.InlineInitializer(cgen.Value('int', indexes[1]), indexes[2]), cgen.Line('%s<%s' % (indexes[1], indexes[3])), cgen.Line('++%s' % indexes[1]), cgen.Block(body_tmp))]
             if not self.pluto and self.ivdep and indexes[0] == self.dimension-1:
-                body_tmp.insert(0, cgen.Statement(self.compiler._ivdep))
+                body_tmp.insert(0, self.compiler._ivdep)
             if not self.pluto and self.simd and indexes[0] == self.dimension-1:
                 body_tmp.insert(0, cgen.Pragma('simd'))
             body = body + body_tmp
@@ -1194,7 +1194,7 @@ class StaggeredGrid(Grid):
                                     body = [cgen.Statement(ccode_eq(bc).replace('[_t + 1]', '[_t1]').replace('[_t]', '[_t0]')) for bc in bc_list]
                                 body = [cgen.For(cgen.InlineInitializer(cgen.Value('int', i), i0), cgen.Line('%s<%s' % (i, i1)), cgen.Line('++%s' % i), cgen.Block(body))]
                                 if self.ivdep:
-                                    body.insert(0, cgen.Pragma('ivdep'))
+                                    body.insert(0, self.compiler._ivdep)
                                 if self.simd:
                                     body.insert(0, cgen.Pragma('simd'))
                             else:
@@ -1243,7 +1243,7 @@ class StaggeredGrid(Grid):
                                     body = [cgen.Statement(ccode_eq(bc).replace('[_t + 1]', '[_t1]').replace('[_t]', '[_t0]')) for bc in bc_list]
                                 body = [cgen.For(cgen.InlineInitializer(cgen.Value('int', i), i0), cgen.Line('%s<%s' % (i, i1)), cgen.Line('++%s' % i), cgen.Block(body))]
                                 if self.ivdep:
-                                    body.insert(0, cgen.Pragma('ivdep'))
+                                    body.insert(0, self.compiler._ivdep)
                                 if self.simd:
                                     body.insert(0, cgen.Pragma('simd'))
                             else:

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -831,12 +831,25 @@ class StaggeredGrid(Grid):
         return result
     
     @property
-    def store_fields(self):
+    def store_fields_old(self):
         """Code fragment that stores field arrays to 'grid' struct"""
-        return '\n'.join(['grid->%s = (%s*) %s;' %
+        result = '\n'.join(['grid->%s = (%s*) %s;' %
                           (ccode(f.label), self.real_t, ccode(f.label))
                           for f in self.fields])
-
+        print result
+        print self.store_fields_cgen
+        return result
+    
+    @property
+    def store_fields(self):
+        """Code fragment that stores field arrays to 'grid' struct"""
+        result = ''
+        for f in self.fields:
+            assignment = cgen.Assign('grid->%s'%ccode(f.label), '(%s*) %s'%(self.real_t, ccode(f.label))) #There must be a better way of doing this. This hardly seems better than string manipulation
+            result+=str(assignment)+'\n'
+        
+        return result
+    
     @property
     def load_fields(self):
         """Code fragment that loads field arrays from 'grid' struct"""

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -851,15 +851,33 @@ class StaggeredGrid(Grid):
         return result
     
     @property
-    def load_fields(self):
+    def load_fields_old(self):
         """Code fragment that loads field arrays from 'grid' struct"""
         idxs = ''.join(['[%d]' % d.value for d in self.dim])
+        print idxs
         result = '\n'.join(['%s (*%s)%s = (%s (*)%s) grid->%s;' %
                           (self.real_t, ccode(f.label), idxs,
                            self.real_t, idxs, ccode(f.label))
                           for f in self.fields])
         print result
+        print self.load_fields_cgen
         return result
+    
+    @property
+    def load_fields(self):
+        """Code fragment that loads field arrays from 'grid' struct"""
+        idxs = ''.join(['[%d]' % d.value for d in self.dim])
+        
+        result = ''
+        for f in self.fields:
+            #back_assign = cgen.Initializer(cgen.Pointer(cgen.Value(self.real_t, ccode(f.label)+idxs)), '(%s (*)%s) grid->%s'%(self.real_t, idxs, ccode(f.label)))
+            #back_assign = cgen.Initializer(cgen.Pointer(cgen.ArrayOf(cgen.ArrayOf(cgen.ArrayOf(cgen.Value(self.real_t, "(%s)"%ccode(f.label)), 105), 105),105)), '(%s (*)[105][105][105]) grid->%s'%(self.real_t, ccode(f.label)))
+            back_assign = cgen.Initializer(cgen.Value(self.real_t, "(*%s)%s"%(ccode(f.label), idxs)), '(%s (*)[105][105][105]) grid->%s'%(self.real_t, ccode(f.label)))
+            result+=str(back_assign)+'\n'
+        
+        
+        return result
+    
     @property
     def declare_fields(self):
         """

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -786,6 +786,9 @@ class StaggeredGrid(Grid):
                 line += 'const '
             line += v.type + ' ' + v.name + ' = ' + str(v.value) + ';\n'
             result += line
+        print "****"
+        print result
+        print "****"
         return result
 
     @property

--- a/opesci/staggeredgrid.py
+++ b/opesci/staggeredgrid.py
@@ -854,11 +854,12 @@ class StaggeredGrid(Grid):
     def load_fields(self):
         """Code fragment that loads field arrays from 'grid' struct"""
         idxs = ''.join(['[%d]' % d.value for d in self.dim])
-        return '\n'.join(['%s (*%s)%s = (%s (*)%s) grid->%s;' %
+        result = '\n'.join(['%s (*%s)%s = (%s (*)%s) grid->%s;' %
                           (self.real_t, ccode(f.label), idxs,
                            self.real_t, idxs, ccode(f.label))
                           for f in self.fields])
-
+        print result
+        return result
     @property
     def declare_fields(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Mako>=1.0.1
 flake8>=2.1.0
 mpmath>=0.19
 -e git://github.com/firedrakeproject/pybench.git#egg=pybench
+
+git+git://github.com/inducer/cgen

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ class CMakeBuilder(build_clib):
 
         # Run cmake and make in temp dir
         self.mkpath(build_dir)
-        chdir(build_dir)
-	print "done1"        
+        chdir(build_dir)     
 	cmake_cmd = ["cmake", root_dir]
         if subprocess.call(cmake_cmd) != 0:
             raise EnvironmentError("error calling cmake")

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,15 @@ class CMakeBuilder(build_clib):
         # Run cmake and make in temp dir
         self.mkpath(build_dir)
         chdir(build_dir)
-        cmake_cmd = ["cmake", root_dir]
+	print "done1"        
+	cmake_cmd = ["cmake", root_dir]
         if subprocess.call(cmake_cmd) != 0:
             raise EnvironmentError("error calling cmake")
 
         if subprocess.call("make") != 0:
             raise EnvironmentError("error calling make")
         chdir(root_dir)
-
+	
         # Copy lib and include directories to opesci package
         self.copy_tree(path.join(root_dir, 'include'),
                        path.join(clib_dir, 'opesci/include'))

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -170,7 +170,6 @@ def default(compiler=None, execute=False, nthreads=1,
     out = None
     if pluto:
         grid.generate(filename)
-        
         filename_p = grid.pluto_op(filename)
         if compiler in ['clang', 'clang++']:
             # an ugly fix, but pluto will always attack <omp.h> to the first line
@@ -191,9 +190,7 @@ def default(compiler=None, execute=False, nthreads=1,
             grid.generate(filename_p)
         else:
             out = grid.compile(filename_p, compiler=compiler, shared=False)
-    
-    
-    
+
     if execute:
         # Test Python-based execution for the base test
         grid.execute(filename_p, compiler=compiler, nthreads=nthreads)

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -45,7 +45,7 @@ def eigenwave3d(domain_size, grid_size, dt, tmax, output_vts=False, o_converge=T
 
     print 'domain size: ' + str(domain_size)
     print 'grid size: ' + str(grid_size)
-    print 'approxmiation order: ' + str(accuracy_order)
+    print 'approximation order: ' + str(accuracy_order)
     print 'dt: ' + str(dt)
     print 'tmax: ' + str(tmax)
 

--- a/tests/eigenwave3d.py
+++ b/tests/eigenwave3d.py
@@ -169,6 +169,7 @@ def default(compiler=None, execute=False, nthreads=1,
     out = None
     if pluto:
         grid.generate(filename)
+        
         filename_p = grid.pluto_op(filename)
         if compiler in ['clang', 'clang++']:
             # an ugly fix, but pluto will always attack <omp.h> to the first line
@@ -189,7 +190,9 @@ def default(compiler=None, execute=False, nthreads=1,
             grid.generate(filename_p)
         else:
             out = grid.compile(filename_p, compiler=compiler, shared=False)
-
+    
+    
+    
     if execute:
         # Test Python-based execution for the base test
         grid.execute(filename_p, compiler=compiler, nthreads=nthreads)


### PR DESCRIPTION
This branch addresses Issue [#57](https://github.com/opesci/opesci-fd/issues/57)
The C source code generation has been updated to use the [Cgen](https://github.com/inducer/cgen) python module. 
However this is still not a complete in-memory AST as the syntax tree is only maintained at the code-block level and is finally converted to a string and added to a template by [grid.py](https://github.com/opesci/opesci-fd/blob/cgen_ast/opesci/grid.py#L66). I would like to get some feedback on the changes so far before I go ahead and change this last function. 
Even though this is not a complete in-memory AST, this pull-request already achieves two of the objectives listed in Issue [#57](https://github.com/opesci/opesci-fd/issues/57), i.e. code readability and maintainability have improved and so has the pretty-print of the generated C code. 